### PR TITLE
Use audio/mpeg content type

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -39,15 +39,7 @@ exports.work = (audioEvent) => {
 // upload mp3 and make copies as needed
 exports.uploadAndCopy = (file) => {
   let dest = `${file.path}/${file.name}`;
-
-  // set content type - translate audio/mp* to audio/mpeg
-  let type = file.contentType;
-  if (!type && file.format) {
-     type = `audio/${file.format}`;
-  }
-  if (type && type.match(/audio\/mp./)) {
-    type = 'audio/mpeg';
-  }
+  let type = file.mimeType();
 
   let uploadOriginal;
   if (file.s3Bucket && file.s3Key) {

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -39,10 +39,16 @@ exports.work = (audioEvent) => {
 // upload mp3 and make copies as needed
 exports.uploadAndCopy = (file) => {
   let dest = `${file.path}/${file.name}`;
+
+  // set content type - translate audio/mp* to audio/mpeg
   let type = file.contentType;
   if (!type && file.format) {
      type = `audio/${file.format}`;
   }
+  if (type && type.match(/audio\/mp./)) {
+    type = 'audio/mpeg';
+  }
+
   let uploadOriginal;
   if (file.s3Bucket && file.s3Key) {
     uploadOriginal = this.copy(file.s3Bucket, file.s3Key, dest, type);

--- a/lib/uploaded-file.js
+++ b/lib/uploaded-file.js
@@ -87,6 +87,20 @@ module.exports = class UploadedFile {
     });
   }
 
+  mimeType() {
+    if (['mp1', 'mp2', 'mp3', 'mpg', 'mpeg'].indexOf(this.format) > -1) {
+      return 'audio/mpeg';
+    } else if (['mp4', 'm4a'].indexOf(this.format) > -1) {
+      return 'audio/mp4';
+    } else if (this.format) {
+      return `audio/${this.format}`;
+    } else if (this.contentType) {
+      return this.contentType; // fallback: trust downloaded content type
+    } else {
+      return undefined;
+    }
+  }
+
   callback() {
     return Q.ninvoke(sqs, 'sendMessage', {
       MessageBody: this.toJSON(),

--- a/test/processor/download-test.js
+++ b/test/processor/download-test.js
@@ -22,7 +22,7 @@ describe('processor-download', () => {
     return processor.download(url).then(data => {
       expect(data.name).to.equal('test.mp3');
       expect(data.localPath).to.equal('/tmp/test.mp3');
-      expect(data.contentType).to.equal('audio/mp3');
+      expect(data.contentType).to.equal('audio/mpeg');
       expect(helper.readSize(data.localPath)).to.equal(12582);
     });
   });

--- a/test/processor/upload-test.js
+++ b/test/processor/upload-test.js
@@ -26,7 +26,7 @@ describe('processor-upload', () => {
 
     let file = {
       name: 'test.mp3',
-      contentType: 'audio/mp3',
+      mimeType: () => 'audio/mpeg',
       localPath: helper.readPath('test.mp3'),
       path: TEST_PATH,
       s3Bucket: null,
@@ -53,8 +53,7 @@ describe('processor-upload', () => {
     this.timeout(4000);
     let file = {
       name: 'test.mp3',
-      contentType: null,
-      format: 'something',
+      mimeType: () => 'audio/something',
       localPath: helper.readPath('test.mp3'),
       path: TEST_PATH,
       s3Bucket: process.env.TEST_BUCKET,

--- a/test/processor/upload-test.js
+++ b/test/processor/upload-test.js
@@ -43,7 +43,7 @@ describe('processor-upload', () => {
         expect(keys).to.include(`${TEST_PATH}/test_broadcast.mp3`);
 
         return helper.getContentTypes(keys).then(types => {
-          expect(types).to.have.members(['audio/mp3']);
+          expect(types).to.have.members(['audio/mpeg']);
         });
       });
     });
@@ -54,7 +54,7 @@ describe('processor-upload', () => {
     let file = {
       name: 'test.mp3',
       contentType: null,
-      format: 'mpfoo',
+      format: 'something',
       localPath: helper.readPath('test.mp3'),
       path: TEST_PATH,
       s3Bucket: process.env.TEST_BUCKET,
@@ -71,7 +71,7 @@ describe('processor-upload', () => {
         expect(keys).to.include(`${TEST_PATH}/test_broadcast.mp3`);
 
         return helper.getContentTypes(keys).then(types => {
-          expect(types).to.have.members(['audio/mpfoo']);
+          expect(types).to.have.members(['audio/something']);
         });
       });
     });

--- a/test/support/test-helper.js
+++ b/test/support/test-helper.js
@@ -43,7 +43,7 @@ exports.putS3TestFile = (fileName, bucket, folder) => {
         ACL: 'public-read',
         Body: exports.readFile(fileName),
         Bucket: bucket,
-        ContentType: 'audio/mp3',
+        ContentType: 'audio/mpeg',
         Expires: exports.minutesFromNow(5),
         Key: `${folder}/${fileName}`
       });

--- a/test/uploaded-file-test.js
+++ b/test/uploaded-file-test.js
@@ -2,6 +2,12 @@
 
 const helper = require('./support/test-helper');
 const UploadedFile = require('../lib/uploaded-file');
+const mimeType = (format, type) => {
+  let file = new UploadedFile({});
+  file.format = format;
+  file.contentType = type;
+  return file.mimeType();
+}
 
 describe('uploaded-file', () => {
 
@@ -53,6 +59,23 @@ describe('uploaded-file', () => {
       'bitrate', 'frequency', 'channels', 'layout', 'downloaded', 'valid', 'processed');
     expect(json.id).to.equal(1234);
     expect(json.path).to.equal('foo/bar');
+  });
+
+  it('gets translated mimetype from file format', () => {
+    expect(mimeType('foo')).to.equal('audio/foo');
+    expect(mimeType('mp1')).to.equal('audio/mpeg');
+    expect(mimeType('mp2')).to.equal('audio/mpeg');
+    expect(mimeType('mp3')).to.equal('audio/mpeg');
+    expect(mimeType('mpg')).to.equal('audio/mpeg');
+    expect(mimeType('mpeg')).to.equal('audio/mpeg');
+    expect(mimeType('mp4')).to.equal('audio/mp4');
+    expect(mimeType('m4a')).to.equal('audio/mp4');
+  });
+
+  it('falls back to the mimetype from the downloaded file', () => {
+    expect(mimeType(null, 'foo/bar')).to.equal('foo/bar');
+    expect(mimeType(null, 'any/thing')).to.equal('any/thing');
+    expect(mimeType(null, null)).to.equal(undefined);
   });
 
   describe('with an sqs queue', () => {


### PR DESCRIPTION
Fixes #4.  Maybe?

- If the original file had a content-type, start with that
- If not, get the content-type based on ffprobe format ... `audio/FORMAT`
- If resulting type looks like `/audio/mp./`, change it to `audio/mpeg`