### PR TITLE
Fail incomplete downloads

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -4,7 +4,8 @@ const url = require('url');
 const path = require('path');
 const fs = require('fs');
 const Q = require('q');
-const request = require('request');
+const http = require('http');
+const https = require('https');
 const s3 = new (require('aws-sdk')).S3();
 const ffmpeg = require('fluent-ffmpeg');
 const UploadedFile = require('./uploaded-file');
@@ -133,10 +134,16 @@ exports.download = (uploadUrl) => {
   return Q.Promise((resolve, _reject) => {
     let reject = err => { err.fromDownload = true; _reject(err) };
     writeStream.on('error', err => reject(err));
-    writeStream.on('close', () => resolve(result));
+    writeStream.on('close', () => {
+      if (result.contentLength && +result.contentLength !== writeStream.bytesWritten) {
+        _reject(new Error(`Expected ${result.contentLength} bytes from ${uploadUrl} - got ${writeStream.bytesWritten}`));
+      } else {
+        resolve(result);
+      }
+    });
 
     if (!uploadUrl) {
-      getRemoteFile = reject(new Error('No url set for event'));
+      _reject(new Error('No url set for event'));
     } else if (uploadUrl.startsWith('s3://')) {
       let m = uploadUrl.match(/s3:\/\/([^\/]+)\/(.*)/);
       result.s3Bucket = m[1];
@@ -146,17 +153,15 @@ exports.download = (uploadUrl) => {
         .on('error', err => reject(err))
         .pipe(writeStream);
     } else if (uploadUrl.match(/^https?:\/\//)) {
-      let params = {url: uploadUrl, encoding: null};
-      request.get(params)
-        .on('response', resp => {
-          if (resp.statusCode !== 200) {
-            reject(new Error(`Got ${resp.statusCode} for url: ${uploadUrl}`));
-          } else if (resp.headers['content-type']) {
-            result.contentType = resp.headers['content-type'];
-          }
-        })
-        .on('error', err => reject(err))
-        .pipe(writeStream);
+      (uploadUrl.match(/^https/) ? https : http).get(uploadUrl, resp => {
+        if (resp.statusCode !== 200) {
+          reject(new Error(`Got ${resp.statusCode} for url: ${uploadUrl}`));
+        } else {
+          result.contentType = resp.headers['content-type'];
+          result.contentLength = resp.headers['content-length'];
+          resp.pipe(writeStream);
+        }
+      }).on('error', err => reject(err));
     } else {
       reject(new Error(`Unrecognized url format: ${uploadUrl}`));
     }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -29,9 +29,10 @@ exports.work = (audioEvent) => {
     return true; // success!
   }).catch(err => {
     if (err.fromDownload || err.fromValidate) {
-      return false; // non-fatal errors
+      file.setError(err);
+      return false;
     }
-    throw err;
+    throw err; // will be retried by SNS
   }).finally(() => {
     return file.callback();
   });

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -143,7 +143,7 @@ exports.download = (uploadUrl) => {
     });
 
     if (!uploadUrl) {
-      _reject(new Error('No url set for event'));
+      reject(new Error('No url set for event'));
     } else if (uploadUrl.startsWith('s3://')) {
       let m = uploadUrl.match(/s3:\/\/([^\/]+)\/(.*)/);
       result.s3Bucket = m[1];

--- a/lib/uploaded-file.js
+++ b/lib/uploaded-file.js
@@ -33,6 +33,7 @@ module.exports = class UploadedFile {
     this.downloaded = false;
     this.valid = false;
     this.processed = false;
+    this.error = null;
   }
 
   setDownloaded(downloadData) {
@@ -69,6 +70,10 @@ module.exports = class UploadedFile {
     }
   }
 
+  setError(err) {
+    this.error = err ? err.message : null;
+  }
+
   toJSON() {
     return JSON.stringify({
       id: this.id,
@@ -83,7 +88,8 @@ module.exports = class UploadedFile {
       layout: this.layout,
       downloaded: this.downloaded,
       valid: this.valid,
-      processed: this.processed
+      processed: this.processed,
+      error: this.error
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "aws-sdk": "^2.4.7",
     "fluent-ffmpeg": "^2.1.0",
-    "q": "^1.4.1",
-    "request": "^2.73.0"
+    "q": "^1.4.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -30,6 +29,7 @@
     "dotenv": "^2.0.0",
     "istanbul": "^0.4.4",
     "mocha": "^2.5.3",
+    "nock": "^9.0.9",
     "node-lambda": "^0.8.13",
     "sinon": "^1.17.5"
   }

--- a/test/processor/download-test.js
+++ b/test/processor/download-test.js
@@ -27,12 +27,23 @@ describe('processor-download', () => {
     });
   });
 
+  it('throws missing download errors', () => {
+    return processor.download(null).then(
+      (data) => { throw 'should have gotten an error'; },
+      (err) => {
+        expect(err.message).to.match(/no url set/i);
+        expect(err.fromDownload).to.be.falsey;
+      }
+    );
+  });
+
   it('handles s3 errors', () => {
     let url = 's3://foo/bar.jpg';
     return processor.download(url).then(
       (data) => { throw 'should have gotten an error'; },
       (err) => {
         expect(err.message).to.match(/access denied/i);
+        expect(err.fromDownload).to.be.true;
       }
     );
   });
@@ -43,6 +54,7 @@ describe('processor-download', () => {
       (data) => { throw 'should have gotten an error'; },
       (err) => {
         expect(err.message).to.match(/got 404 for/i);
+        expect(err.fromDownload).to.be.true;
       }
     );
   });
@@ -53,6 +65,7 @@ describe('processor-download', () => {
       (data) => { throw 'should have gotten an error'; },
       (err) => {
         expect(err.message).to.match(/ENOTFOUND/i);
+        expect(err.fromDownload).to.be.true;
       }
     );
   });
@@ -63,6 +76,7 @@ describe('processor-download', () => {
       (data) => { throw 'should have gotten an error'; },
       (err) => {
         expect(err.message).to.match(/key does not exist/i);
+        expect(err.fromDownload).to.be.true;
       }
     );
   });
@@ -73,8 +87,31 @@ describe('processor-download', () => {
       (data) => { throw 'should have gotten an error'; },
       (err) => {
         expect(err.message).to.match(/unrecognized url format/i);
+        expect(err.fromDownload).to.be.true;
       }
     );
+  });
+
+  it('throws content-length mismatch errors', () => {
+    nock('http://foo.bar').get('/mismatch.mp3').reply(200, '--mp3--', {'Content-Length': 11});
+    return processor.download('http://foo.bar/mismatch.mp3').then(
+      (data) => { throw 'should have gotten an error'; },
+      (err) => {
+        expect(err.message).to.match(/expected 11 bytes/i);
+        expect(err.message).to.match(/got 7/i);
+        expect(err.fromDownload).to.be.falsey;
+      }
+    );
+  });
+
+  it('is okay with matching content-length', () => {
+    nock('http://foo.bar').get('/okay.mp3').reply(200, '--mp3--', {'Content-Length': 7});
+    return processor.download('http://foo.bar/okay.mp3').then(data => {
+      expect(data.name).to.equal('okay.mp3');
+      expect(data.localPath).to.equal('/tmp/okay.mp3');
+      expect(data.contentType).to.be.undefined;
+      expect(helper.readSize(data.localPath)).to.equal(7);
+    });
   });
 
 });

--- a/test/processor/download-test.js
+++ b/test/processor/download-test.js
@@ -27,12 +27,12 @@ describe('processor-download', () => {
     });
   });
 
-  it('throws missing download errors', () => {
+  it('handles missing download errors', () => {
     return processor.download(null).then(
       (data) => { throw 'should have gotten an error'; },
       (err) => {
         expect(err.message).to.match(/no url set/i);
-        expect(err.fromDownload).to.be.falsey;
+        expect(err.fromDownload).to.be.true;
       }
     );
   });

--- a/test/processor/work-test.js
+++ b/test/processor/work-test.js
@@ -74,6 +74,7 @@ describe('processor-work', () => {
       expect(file.downloaded).to.equal(true);
       expect(file.valid).to.equal(false);
       expect(file.processed).to.equal(false);
+      expect(file.error).to.match(/non-audio file/i);
     });
   });
 
@@ -87,6 +88,7 @@ describe('processor-work', () => {
       expect(file.downloaded).to.equal(false);
       expect(file.valid).to.equal(false);
       expect(file.processed).to.equal(false);
+      expect(file.error).to.match(/got 403 for url:/i);
     });
   });
 
@@ -101,6 +103,7 @@ describe('processor-work', () => {
         expect(file.downloaded).to.equal(true);
         expect(file.valid).to.equal(true);
         expect(file.processed).to.equal(false);
+        expect(file.error).to.be.null;
       }
     );
   });
@@ -113,6 +116,8 @@ describe('processor-work', () => {
       (success) => { throw 'should have gotten an error'; },
       (err) => {
         expect(err.message).to.match(/sqs-err/i);
+        let file = getUploadedFile();
+        expect(file.error).to.be.null;
       }
     );
   });

--- a/test/support/test-helper.js
+++ b/test/support/test-helper.js
@@ -14,6 +14,7 @@ const AudioEvent = require('../../lib/audio-event');
 global.expect = require('chai').expect;
 global.Q = require('q');
 global.sinon = require('sinon');
+global.nock = require('nock');
 
 // helper methods
 exports.minutesFromNow = (mins) => {

--- a/test/uploaded-file-test.js
+++ b/test/uploaded-file-test.js
@@ -50,13 +50,23 @@ describe('uploaded-file', () => {
     expect(file.processed).to.equal(true);
   });
 
+  it('sets error messages', () => {
+    let file = new UploadedFile({});
+    expect(file.error).to.equal(null);
+    file.setError();
+    expect(file.error).to.equal(null);
+    file.setError(new Error('Something went wrong'));
+    expect(file.error).to.equal('Something went wrong');
+  });
+
   it('serializes to json', () => {
     let file = new UploadedFile({audioId: 1234, audioType: 'foo', audioDestinationPath: 'foo/bar'});
     file.setDownloaded({name: 'foo.bar'});
     file.setValidated();
     let json = JSON.parse(file.toJSON());
     expect(json).to.have.keys('id', 'path', 'name', 'duration', 'size', 'format',
-      'bitrate', 'frequency', 'channels', 'layout', 'downloaded', 'valid', 'processed');
+      'bitrate', 'frequency', 'channels', 'layout', 'downloaded', 'valid',
+      'processed', 'error');
     expect(json.id).to.equal(1234);
     expect(json.path).to.equal('foo/bar');
   });


### PR DESCRIPTION
- Remove `request` and just use native `http` / `https` instead.  (Wasn't really buying us anything).
- HTTP downloads with a `Content-Length` header should write that many bytes to the stream. Reject downloads that do not.
- Test for `fromDownload` errors (which will callback to CMS with the failure), vs fatal errors (which will fail the lambda execution).

According to [the lambda docs](http://docs.aws.amazon.com/lambda/latest/dg/retries-on-errors.html), any fatal errors should be retried per the delivery policies set in SNS.  And our topics are configured for 3 retries.