### PR TITLE
Ignore video streams without bitrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ SQS callbacks contain the following JSON data:
 
 | Key  | Sub-key    | Description |
 | ---- | ---------- | ----------- |
-| id   |            | ID of the SNS message that triggered this job
+| id   |            | ID of the AudioFile that triggered this job
 | path |            | Destination path in S3 the file was copied to
 | name |            | File name
 | mime |            | Mime-type of the file


### PR DESCRIPTION
Many mp3s have an image stream attached (the id3 image).  For some reason, ffprobe _does_ see a duration associated with it - so current logic would identify it as a "video".  Leading to the wrong contentType, and eventually CMS validation will fail because it thinks you uploaded a video.

This change also checks for a video bitrate > 0.  From what I've seen, none of these "image streams" have a bitrate associated.