### PR TITLE
Also send retryable errors over SQS

### DIFF
--- a/lib/processor/index.js
+++ b/lib/processor/index.js
@@ -26,12 +26,14 @@ exports.work = (audioEvent) => {
     file.setProcessed(results[1]);
     return file.callback().then(() => true);
   }).catch(err => {
+    file.setError(err);
     if (err.noRetry) {
       logger.warn(`NoRetry ${err.message}`);
-      file.setError(err);
       return file.callback().then(() => false);
     } else {
-      throw err; // will be retried by SNS
+      return file.callback().then(() => {
+        throw err; // will be retried by SNS
+      });
     }
   }).finally(() => {
     if (file.localPath) {


### PR DESCRIPTION
Always send the error message over SQS, before retrying.  This prevents infinitely retrying an audio file (until it hits the SNS retry limit), without ever letting CMS know what went wrong.